### PR TITLE
Remove password character cap

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -419,7 +419,7 @@ router.post('/register', accountLimiter, wrap(async (req, res, next) => {
   // 4th Check: Password length
   let password = req.body.password
   if (!password || password.length < 8) {
-    return formError(req, res, 'Invalid password! Keep it between 8 and 32 characters!')
+    return formError(req, res, 'Invalid password! Please use at least 8 characters!')
   }
 
   // 5th Check: Password match
@@ -532,7 +532,7 @@ router.post('/user/manage/password', accountLimiter, wrap(async (req, res, next)
 
   let password = req.body.password
   if (!password || password.length < 8) {
-    return formError(req, res, 'Invalid password! Keep it between 8 and 32 characters!')
+    return formError(req, res, 'Invalid password! Please use at least 8 characters!')
   }
 
   let passwordAgain = req.body.password_repeat

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -418,7 +418,7 @@ router.post('/register', accountLimiter, wrap(async (req, res, next) => {
 
   // 4th Check: Password length
   let password = req.body.password
-  if (!password || password.length < 8 || password.length > 32) {
+  if (!password || password.length < 8) {
     return formError(req, res, 'Invalid password! Keep it between 8 and 32 characters!')
   }
 
@@ -531,7 +531,7 @@ router.post('/user/manage/password', accountLimiter, wrap(async (req, res, next)
   }
 
   let password = req.body.password
-  if (!password || password.length < 8 || password.length > 32) {
+  if (!password || password.length < 8) {
     return formError(req, res, 'Invalid password! Keep it between 8 and 32 characters!')
   }
 


### PR DESCRIPTION
Password cap is no longer necessary as bcrypt supports any length under 70 characters, and only truncates passwords longer than 70 characters.  Removing the cap allows users to use longer and more secure passwords.